### PR TITLE
Adding 'Bits Per Sample' to identify-output

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var conversions = {
   channelCount: int,
   duration: float,
   bitRate: parseBitRate,
+  bitsPerSample: int
 }
 var suffixMultiplier = {
   'k': 1024,
@@ -60,6 +61,7 @@ function identify(inputFile, callback){
   soxInfo('-s', function(value) { results.sampleCount   = value; });
   soxInfo('-D', function(value) { results.duration      = value; });
   soxInfo('-B', function(value) { results.bitRate       = value; });
+  soxInfo('-b', function(value) { results.bitsPerSample = value; });
 
   batch.end(function(err) {
     if (err) return callback(err);

--- a/test/test.js
+++ b/test/test.js
@@ -19,6 +19,7 @@ describe("sox", function () {
           sampleCount: 66150,
           channelCount: 1,
           bitRate: 722944,
+          bitsPerSample: 16,
           sampleRate: 44100,
         });
         done();
@@ -33,6 +34,7 @@ describe("sox", function () {
           sampleCount: 47231,
           channelCount: 1,
           bitRate: 132096,
+          bitsPerSample: 0,
           sampleRate: 44100,
         });
         done();


### PR DESCRIPTION
This pull request adds "bits per sample" support to the `identify` output and updates affected tests.

From running `sox --info --help`:

> -b    Show number of bits per sample (0 if not applicable)
